### PR TITLE
Add additional fields to data acceleration config (#588)

### DIFF
--- a/tableauserverclient/models/property_decorators.py
+++ b/tableauserverclient/models/property_decorators.py
@@ -144,8 +144,10 @@ def property_is_data_acceleration_config(func):
         if not isinstance(value, dict):
             raise ValueError("{} is not type 'dict', cannot update {})".format(value.__class__.__name__,
                                                                                func.__name__))
-        if len(value) != 2 or not all(attr in value.keys() for attr in ('acceleration_enabled',
-                                                                        'accelerate_now')):
+        if len(value) != 4 or not all(attr in value.keys() for attr in ('acceleration_enabled',
+                                                                        'accelerate_now',
+                                                                        'last_updated_at',
+                                                                        'acceleration_status')):
             error = "{} should have 2 keys ".format(func.__name__)
             error += "'acceleration_enabled' and 'accelerate_now'"
             error += "instead you have {}".format(value.keys())

--- a/tableauserverclient/models/workbook_item.py
+++ b/tableauserverclient/models/workbook_item.py
@@ -28,7 +28,9 @@ class WorkbookItem(object):
         self.show_tabs = show_tabs
         self.tags = set()
         self.data_acceleration_config = {'acceleration_enabled': None,
-                                         'accelerate_now': None}
+                                         'accelerate_now': None,
+                                         'last_updated_at': None,
+                                         'acceleration_status': None}
         self._permissions = None
 
     @property
@@ -248,7 +250,8 @@ class WorkbookItem(object):
         if views_elem is not None:
             views = ViewItem.from_xml_element(views_elem, ns)
 
-        data_acceleration_config = {'acceleration_enabled': None, 'accelerate_now': None}
+        data_acceleration_config = {'acceleration_enabled': None, 'accelerate_now': None,
+                                    'last_updated_at': None, 'acceleration_status': None}
         data_acceleration_elem = workbook_xml.find('.//t:dataAccelerationConfig', namespaces=ns)
         if data_acceleration_elem is not None:
             data_acceleration_config = parse_data_acceleration_config(data_acceleration_elem)
@@ -268,8 +271,16 @@ def parse_data_acceleration_config(data_acceleration_elem):
     if accelerate_now is not None:
         accelerate_now = string_to_bool(accelerate_now)
 
+    last_updated_at = data_acceleration_elem.get('lastUpdatedAt', None)
+    if last_updated_at is not None:
+        last_updated_at = parse_datetime(last_updated_at)
+
+    acceleration_status = data_acceleration_elem.get('accelerationStatus', None)
+
     data_acceleration_config['acceleration_enabled'] = acceleration_enabled
     data_acceleration_config['accelerate_now'] = accelerate_now
+    data_acceleration_config['last_updated_at'] = last_updated_at
+    data_acceleration_config['acceleration_status'] = acceleration_status
     return data_acceleration_config
 
 

--- a/tableauserverclient/server/request_options.py
+++ b/tableauserverclient/server/request_options.py
@@ -11,6 +11,7 @@ class RequestOptions(RequestOptionsBase):
         LessThan = 'lt'
         LessThanOrEqual = 'lte'
         In = 'in'
+        Has = 'has'
 
     class Field:
         Args = 'args'

--- a/test/assets/workbook_update.xml
+++ b/test/assets/workbook_update.xml
@@ -4,6 +4,6 @@
         <project id="1d0304cd-3796-429f-b815-7258370b9b74" name="Tableau" />
         <owner id="dd2239f6-ddf1-4107-981a-4cf94e415794" />
         <tags />
-        <materializedViewsEnablementConfig materializedViewsEnabled="true" runMaterializationNow="false" />
+        <dataAccelerationConfig accelerationEnabled="true" accelerateNow="false" />
     </workbook>
 </tsResponse>

--- a/test/test_workbook.py
+++ b/test/test_workbook.py
@@ -131,8 +131,10 @@ class WorkbookTests(unittest.TestCase):
             single_workbook._id = '1f951daf-4061-451a-9df1-69a8062664f2'
             single_workbook.owner_id = 'dd2239f6-ddf1-4107-981a-4cf94e415794'
             single_workbook.name = 'renamedWorkbook'
-            single_workbook.materialized_views_config = {'materialized_views_enabled': True,
-                                                         'run_materialization_now': False}
+            single_workbook.data_acceleration_config = {'acceleration_enabled': True,
+                                                        'accelerate_now': False,
+                                                        'last_updated_at': None,
+                                                        'acceleration_status': None}
             single_workbook = self.server.workbooks.update(single_workbook)
 
         self.assertEqual('1f951daf-4061-451a-9df1-69a8062664f2', single_workbook.id)
@@ -140,8 +142,8 @@ class WorkbookTests(unittest.TestCase):
         self.assertEqual('1d0304cd-3796-429f-b815-7258370b9b74', single_workbook.project_id)
         self.assertEqual('dd2239f6-ddf1-4107-981a-4cf94e415794', single_workbook.owner_id)
         self.assertEqual('renamedWorkbook', single_workbook.name)
-        self.assertEqual(True, single_workbook.materialized_views_config['materialized_views_enabled'])
-        self.assertEqual(False, single_workbook.materialized_views_config['run_materialization_now'])
+        self.assertEqual(True, single_workbook.data_acceleration_config['acceleration_enabled'])
+        self.assertEqual(False, single_workbook.data_acceleration_config['accelerate_now'])
 
     def test_update_missing_id(self):
         single_workbook = TSC.WorkbookItem('test')


### PR DESCRIPTION
* fixing a bug due to bool(time(0,0)) is false

* replace materialized views with data acceleration

* made changes in tests

* fixed a unit test

* restore deleted lines by mistake

* replace materialize_workbooks.py with accelerate_workbooks.py

* undo a fix to test_sort.py

* format changes

* another format change

* format change

* remove accelerate_workbooks.py

* adding additional fields to data_acceleration_config

Co-authored-by: dguo <dguo@tableau.com>